### PR TITLE
ROCANA-10101

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "definitions"]
 	path = definitions
-	url = https://github.com/cloudfoundry/dropsonde-protocol.git
+	url = ssh://git@github.com/scalingdata/dropsonde-protocol.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "definitions"]
 	path = definitions
-	url = ssh://git@github.com/scalingdata/dropsonde-protocol.git
+	url = ssh://git@github.com:scalingdata/dropsonde-protocol.git
 	branch = master


### PR DESCRIPTION
Update .gitmodules to use ssh://git@github.com:scalingdata/dropsonde-protocol.git,
instead of https://github.com/cloudfoundr/dropsonde-protocol.git -
note change of protocol (https -> ssh),
specification of user (git@github.com),
and change of repo owner (cloudfoundry -> scalingdata).

This change is intended to:
1/ give us control & stability over this dependency, and
2/ enable use of Glide on Windows to manage dependencies,
which was stumbling on previous configuration.